### PR TITLE
keyball44風キーマップに変更

### DIFF
--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -49,7 +49,7 @@
 &kp Q           &kp W         &kp E         &kp R    &kp T                                       &kp Y          &kp U     &kp I      &kp O    &kp P
 &kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp ENTER
 &kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &mkp MB1   &mo 3    &kp SLASH
-&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp INT5           &kp F13      &kp INT_HENKAN &mo 2                        &kp DEL
+&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp F13            &kp INT5     &kp INT_HENKAN &mo 2                        &kp DEL
             >;
 
             sensor-bindings =

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -48,7 +48,7 @@
             bindings = <
 &kp Q           &kp W         &kp E         &kp R    &kp T                                       &kp Y          &kp U     &kp I      &kp O    &kp P
 &kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp ENTER
-&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &mkp MB1   &mo 3    &kp SLASH
+&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &mkp MB1   &mo 2    &kp BACKSPACE
 &kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp F13            &kp INT5     &kp INT_HENKAN &mo 2                        &kp DEL
             >;
 

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -46,10 +46,10 @@
 
         default_layer {
             bindings = <
-&kp Q           &kp W         &kp E         &kp R    &kp T                                       &kp Y          &kp U     &kp I      &kp O    &kp P
-&kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp ENTER
-&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &mkp MB1   &mo 2    &kp BACKSPACE
-&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp F13            &kp INT5     &kp INT_HENKAN &mo 2                        &kp DEL
+&kp Q      &kp W         &kp E             &kp R  &kp T                             &kp Y           &kp U  &kp I     &kp O  &kp P
+&kp A      &kp S         &kp D             &kp F  &kp G                   &kp F15   &kp H           &kp J  &kp K     &kp L  &kp ENTER
+&kp Z      &kp X         &kp C             &kp V  &kp B      &kp LCTRL    &kp F16   &kp N           &kp M  &mkp MB1  &mo 2  &kp BACKSPACE
+&kp RCTRL  &kp LEFT_ALT  &kp LEFT_COMMAND  &mo 1  &kp SPACE  &kp F13      &kp INT5  &kp INT_HENKAN                          &kp F14
             >;
 
             sensor-bindings =
@@ -59,10 +59,10 @@
 
         layer_1 {
             bindings = <
-&kp EXCL      &kp DQT       &kp HASH       &kp AMPERSAND  &kp PERCENT                          &kp CARET             &kp DOLLAR        &kp LEFT_PARENTHESIS &kp RIGHT_PARENTHESIS &kp AT
-&kp QUESTION  &kp SQT       &kp TILDE      &kp PIPE       &kp NUMBER_0              &kp F20    &kp LEFT_BRACKET      &kp RIGHT_BRACKET &kp LEFT_BRACE       &kp RIGHT_BRACE       &kp SEMICOLON
-&kp INT_YEN   &kp ASTERISK  &kp MINUS      &kp PLUS       &kp EQUAL     &kp F19     &trans     &kp LESS_THAN         &kp GREATER_THAN  &kp DOT              &kp COMMA             &kp COLON
-&trans        &trans        &trans         &trans         &trans        &kp F17     &kp F18    &trans                &mo 2                                                    &kp SLASH
+&kp EXCL      &kp DQT       &kp HASH   &kp AMPERSAND  &kp PERCENT                       &kp CARET         &kp DOLLAR         &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp AT
+&kp QUESTION  &kp SQT       &kp TILDE  &kp PIPE       &kp NUMBER_0             &kp F20  &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp SEMICOLON
+&kp INT_YEN   &kp ASTERISK  &kp MINUS  &kp PLUS       &kp EQUAL     &kp F19    &kp F19  &kp LESS_THAN     &kp GREATER_THAN   &kp DOT               &kp COMMA              &kp COLON
+&trans        &trans        &trans     &trans         &trans        &kp F17    &kp F17  &kp F18                                                                           &kp SLASH
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -70,10 +70,10 @@
 
         layer_2 {
             bindings = <
-&kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5                             &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5                           &trans   &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &kp ENTER
-&kp F6        &kp F7        &kp F8        &kp F9        &kp F10       &trans             &trans   &kp HOME      &kp PAGE_DOWN &kp PAGE_UP   &kp END       &trans
-&trans        &trans        &trans        &mo 3         &trans        &trans             &trans   &trans        &trans                                    &trans
+&kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5                    &kp NUMBER_6  &kp NUMBER_7   &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &trans  &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &kp RIGHT
+&kp F6        &kp F7        &kp F8        &kp F9        &kp F10       &trans    &trans  &kp HOME      &kp PAGE_DOWN  &kp PAGE_UP   &trans        &trans
+&trans        &trans        &trans        &mo 3         &trans        &trans    &trans  &trans                                                   &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -81,14 +81,13 @@
 
         layer_3 {
             bindings = <
-&bootloader  &trans  &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans       &trans  &trans  &trans  &trans            &trans       &trans        &trans        &trans        &trans        &bt BT_CLR
-&trans       &trans  &trans  &trans  &trans  &trans    &trans       &trans        &trans        &trans        &trans        &bt BT_CLR_ALL
-&trans       &trans  &trans  &trans  &trans  &trans    &trans       &trans        &trans                                    &bootloader
+&bootloader  &trans  &trans  &trans  &trans                    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&trans       &trans  &trans  &trans  &trans            &trans  &trans        &trans        &trans        &trans        &bt BT_CLR
+&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans        &trans        &trans        &trans        &bt BT_CLR_ALL
+&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans                                                  &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
         };
-
     };
 };

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -47,9 +47,9 @@
         default_layer {
             bindings = <
 &kp Q           &kp W         &kp E         &kp R    &kp T                                       &kp Y          &kp U     &kp I      &kp O    &kp P
-&kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp SQT
-&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &kp COMMA  &kp DOT  &kp SLASH
-&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp INT_MUHENKAN   &kp INT_HENKAN  &kp BACKSPACE  &mo 2                        &kp DEL
+&kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp ENTER
+&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &mkp MB1   &mo 3    &kp SLASH
+&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp INT5           &kp F13      &kp INT_HENKAN &mo 2                        &kp DEL
             >;
 
             sensor-bindings =

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -59,10 +59,10 @@
 
         layer_1 {
             bindings = <
-&trans        &kp HASH      &kp AMPERSAND  &kp DOLLAR     &trans                               &kp LEFT_PARENTHESIS  &kp LEFT_BRACKET  &kp LEFT_BRACE  &kp RIGHT_PARENTHESIS  &trans
-&kp EXCL      &kp TILDE     &kp EQUAL      &kp PLUS       &trans                    &trans     &kp RIGHT_BRACE       &kp RIGHT_BRACKET &kp PIPE        &kp ASTERISK           &trans
-&kp CARET     &kp BACKSLASH &trans         &trans         &trans       &trans       &trans     &kp UNDERSCORE        &kp LESS_THAN     &kp GREATER_THAN &kp SLASH             &kp AT
-&trans        &trans        &trans         &trans         &trans       &trans       &trans     &trans                &mo 2                                                 &trans
+&kp EXCL      &kp DQT       &kp HASH       &kp AMPERSAND  &kp PERCENT                          &kp CARET             &kp DOLLAR        &kp LEFT_PARENTHESIS &kp RIGHT_PARENTHESIS &kp AT
+&kp QUESTION  &kp SQT       &kp TILDE      &kp PIPE       &kp NUMBER_0              &kp F20    &kp LEFT_BRACKET      &kp RIGHT_BRACKET &kp LEFT_BRACE       &kp RIGHT_BRACE       &kp SEMICOLON
+&kp INT_YEN   &kp ASTERISK  &kp MINUS      &kp PLUS       &kp EQUAL     &kp F19     &trans     &kp LESS_THAN         &kp GREATER_THAN  &kp DOT              &kp COMMA             &kp COLON
+&trans        &trans        &trans         &trans         &trans        &kp F17     &kp F18    &trans                &mo 2                                                    &kp SLASH
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -72,7 +72,7 @@
             bindings = <
 &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5                    &kp NUMBER_6  &kp NUMBER_7   &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
 &kp F1        &kp F2        &kp F3        &kp F4        &kp F5                  &trans  &kp LEFT      &kp DOWN       &kp UP        &kp RIGHT     &kp RIGHT
-&kp F6        &kp F7        &kp F8        &kp F9        &kp F10       &trans    &trans  &kp HOME      &kp PAGE_DOWN  &kp PAGE_UP   &trans        &trans
+&kp F6        &kp F7        &kp F8        &kp F9        &kp F10       &trans    &trans  &kp HOME      &kp PAGE_DOWN  &kp PAGE_UP   &trans        &kp END
 &trans        &trans        &trans        &mo 3         &trans        &trans    &trans  &trans                                                   &trans
             >;
 
@@ -81,10 +81,10 @@
 
         layer_3 {
             bindings = <
-&bootloader  &trans  &trans  &trans  &trans                    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans       &trans  &trans  &trans  &trans            &trans  &trans        &trans        &trans        &trans        &bt BT_CLR
-&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans        &trans        &trans        &trans        &bt BT_CLR_ALL
-&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans                                                  &trans
+&bootloader  &trans  &trans  &trans  &trans                    &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_CLR  &bt BT_CLR_ALL
+&trans       &trans  &trans  &trans  &trans            &trans  &trans        &trans        &trans        &trans      &trans
+&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans        &trans        &trans        &trans      &trans
+&trans       &trans  &trans  &trans  &trans  &trans    &trans  &trans                                                &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -4,8 +4,6 @@
 #include <dt-bindings/zmk/pointing.h>
 
 #define ZMK_POINTING_DEFAULT_SCRL_VAL 100
-#define MOUSE 5
-#define SCROLL 6
 
 &mt {
     flavor = "balanced";
@@ -48,10 +46,10 @@
 
         default_layer {
             bindings = <
-&kp Q             &kp W         &kp E         &kp R             &kp T                                             &kp Y        &kp U  &lt 5 I    &kp O    &kp P
-&kp A             &kp S         &kp D         &kp F             &kp G                              &kp MINUS      &kp H        &kp J  &kp K      &kp L    &kp SQT
-&mt LEFT_SHIFT Z  &kp X         &kp C         &kp V             &kp B        &lt 4 COLON           &kp SEMICOLON  &kp N        &kp M  &kp COMMA  &kp DOT  &kp SLASH
-&kp LCTRL         &kp LEFT_WIN  &kp LEFT_ALT  &lt 1 INT_HENKAN  &lt 2 SPACE  &lt 3 INT_MUHENKAN    &kp BACKSPACE  &lt 1 ENTER                             &kp DEL
+&kp Q           &kp W         &kp E         &kp R    &kp T                                       &kp Y          &kp U     &kp I      &kp O    &kp P
+&kp A           &kp S         &kp D         &kp F    &kp G                           &mkp MB1     &kp H          &kp J     &kp K      &kp L    &kp SQT
+&kp Z           &kp X         &kp C         &kp V    &kp B        &mkp MB3           &mkp MB2     &kp N          &kp M     &kp COMMA  &kp DOT  &kp SLASH
+&kp LEFT_SHIFT  &kp LCTRL     &kp LEFT_ALT  &mo 1    &kp SPACE    &kp INT_MUHENKAN   &kp INT_HENKAN  &kp BACKSPACE  &mo 2                        &kp DEL
             >;
 
             sensor-bindings =
@@ -61,10 +59,10 @@
 
         layer_1 {
             bindings = <
-&trans  &trans  &trans  &trans  &trans                    &kp F1  &kp F2  &kp F3  &kp F4  &kp F5
-&trans  &trans  &trans  &trans  &trans            &trans  &kp F6  &kp F7  &kp F8  &kp F9  &kp F10
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans  &trans  &trans  &kp F11
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                          &kp F12
+&kp EXCL  &kp AT     &kp HASH   &kp DOLLAR  &kp PERCENT                          &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS
+&kp GRAVE &kp TILDE  &kp EQUAL  &kp PLUS    &kp MINUS                    &trans  &kp UNDERSCORE  &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_BRACE  &kp RIGHT_BRACE
+&trans    &trans     &kp COLON  &kp SEMICOLON  &kp PIPE  &trans         &trans  &kp BACKSLASH  &trans  &trans  &trans  &trans
+&trans    &trans     &trans     &trans      &trans      &trans           &trans  &trans  &mo 3                    &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -72,10 +70,10 @@
 
         layer_2 {
             bindings = <
-&kp MINUS                   &kp KP_NUMBER_7  &kp KP_NUMBER_8  &kp KP_NUMBER_9  &kp PLUS                                                 &kp CARET         &kp AMPERSAND      &kp TILDE       &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS
-&kp SLASH                   &kp KP_NUMBER_4  &kp KP_NUMBER_5  &kp KP_NUMBER_6  &kp ASTERISK                             &kp UNDERSCORE  &kp EXCLAMATION   &kp AT_SIGN        &kp HASH        &kp DOLLAR            &kp PERCENT
-&mt LEFT_SHIFT KP_NUMBER_0  &kp KP_NUMBER_1  &kp KP_NUMBER_2  &kp KP_NUMBER_3  &kp PERIOD    &kp EQUAL                  &trans          &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_BRACE  &kp RIGHT_BRACE       &kp BACKSLASH
-&trans                      &trans           &trans           &trans           &trans        &trans                     &trans          &trans                                                                     &kp PIPE
+&kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp NUMBER_4  &kp NUMBER_5                             &kp NUMBER_6  &kp NUMBER_7  &kp NUMBER_8  &kp NUMBER_9  &kp NUMBER_0
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5                           &trans   &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &kp ENTER
+&kp F6        &kp F7        &kp F8        &kp F9        &kp F10       &trans             &trans   &kp HOME      &kp PAGE_DOWN &kp PAGE_UP   &kp END       &trans
+&trans        &trans        &trans        &mo 3         &trans        &trans             &trans   &trans        &trans                                    &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;
@@ -83,46 +81,14 @@
 
         layer_3 {
             bindings = <
-&kp ESCAPE      &kp LC(LS(TAB))         &kp UP_ARROW    &kp LC(TAB)              &trans                     &trans  &trans  &trans  &trans  &trans
-&kp HOME        &kp LEFT_ARROW          &kp DOWN_ARROW  &kp RIGHT_ARROW          &kp END            &trans  &trans  &trans  &trans  &trans  &trans
-&kp LEFT_SHIFT  &kp LG(LS(LEFT_ARROW))  &trans          &kp LG(LS(RIGHT_ARROW))  &trans   &trans    &trans  &trans  &trans  &trans  &trans  &trans
-&trans          &trans                  &trans          &trans                   &trans   &trans    &trans  &trans                          &trans
+&bootloader  &trans  &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
+&trans       &trans  &trans  &trans  &trans            &trans       &trans        &trans        &trans        &trans        &bt BT_CLR
+&trans       &trans  &trans  &trans  &trans  &trans    &trans       &trans        &trans        &trans        &trans        &bt BT_CLR_ALL
+&trans       &trans  &trans  &trans  &trans  &trans    &trans       &trans        &trans                                    &bootloader
             >;
 
             sensor-bindings = <&scroll_up_down>;
         };
 
-        layer_4 {
-            bindings = <
-&trans  &trans  &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4
-&trans  &trans  &trans  &trans  &trans            &trans       &trans        &trans        &trans        &trans        &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &bootloader  &trans        &trans        &trans        &trans        &bt BT_CLR
-&trans  &trans  &trans  &trans  &trans  &trans    &trans       &trans                                                  &bt BT_CLR_ALL
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
-        };
-
-        MOUSE {
-            bindings = <
-&trans  &trans  &trans  &trans  &trans                    &trans  &trans    &trans    &trans    &trans
-&trans  &trans  &trans  &trans  &trans            &trans  &trans  &mkp MB1  &mkp MB3  &mkp MB2  &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                                &trans
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
-        };
-
-        SCROLL {
-            bindings = <
-&trans  &trans  &trans  &trans  &trans                    &trans  &trans    &trans    &trans    &trans
-&trans  &trans  &trans  &trans  &trans            &trans  &trans  &trans    &trans    &trans    &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans  &trans    &trans    &trans    &trans
-&trans  &trans  &trans  &trans  &trans  &trans    &trans  &trans                                &trans
-            >;
-
-            sensor-bindings = <&scroll_up_down>;
-        };
     };
 };

--- a/config/moNa2.keymap
+++ b/config/moNa2.keymap
@@ -59,10 +59,10 @@
 
         layer_1 {
             bindings = <
-&kp EXCL  &kp AT     &kp HASH   &kp DOLLAR  &kp PERCENT                          &kp CARET  &kp AMPERSAND  &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS
-&kp GRAVE &kp TILDE  &kp EQUAL  &kp PLUS    &kp MINUS                    &trans  &kp UNDERSCORE  &kp LEFT_BRACKET  &kp RIGHT_BRACKET  &kp LEFT_BRACE  &kp RIGHT_BRACE
-&trans    &trans     &kp COLON  &kp SEMICOLON  &kp PIPE  &trans         &trans  &kp BACKSLASH  &trans  &trans  &trans  &trans
-&trans    &trans     &trans     &trans      &trans      &trans           &trans  &trans  &mo 3                    &trans
+&trans        &kp HASH      &kp AMPERSAND  &kp DOLLAR     &trans                               &kp LEFT_PARENTHESIS  &kp LEFT_BRACKET  &kp LEFT_BRACE  &kp RIGHT_PARENTHESIS  &trans
+&kp EXCL      &kp TILDE     &kp EQUAL      &kp PLUS       &trans                    &trans     &kp RIGHT_BRACE       &kp RIGHT_BRACKET &kp PIPE        &kp ASTERISK           &trans
+&kp CARET     &kp BACKSLASH &trans         &trans         &trans       &trans       &trans     &kp UNDERSCORE        &kp LESS_THAN     &kp GREATER_THAN &kp SLASH             &kp AT
+&trans        &trans        &trans         &trans         &trans       &trans       &trans     &trans                &mo 2                                                 &trans
             >;
 
             sensor-bindings = <&scroll_up_down>;


### PR DESCRIPTION
## Summary
- keyball44の設計思想をmoNa2に適用
- 1キー1機能の原則でシンプルな操作性を実現
- レイヤー構成を論理的に整理

## 主な変更点
- **Layer/Tap廃止**: すべてのLayer/Tap機能を削除し、キーの挙動を明確化
- **英数・かな専用キー**: 右親指エリアに無変換（英数）・変換（かな）を配置
- **レイヤー構成の整理**:
  - Layer 0: 基本文字 + マウスボタン（MB1/MB2/MB3）
  - Layer 1: 記号類
  - Layer 2: 数字・カーソル・ファンクションキー
  - Layer 3: Bluetooth設定・システム
- **不要レイヤー削除**: MOUSE, SCROLLレイヤーを削除してシンプル化

## Test plan
- [ ] ファームウェアのビルド確認
- [ ] 各レイヤーの動作確認
- [ ] マウスボタンの動作確認
- [ ] Bluetooth設定の動作確認

🤖 Generated with Claude Code