### PR TITLE
scroll-layersをレイヤー2に変更

### DIFF
--- a/config/boards/shields/moNa2/moNa2_R.overlay
+++ b/config/boards/shields/moNa2/moNa2_R.overlay
@@ -56,7 +56,7 @@
         spi-max-frequency = <2000000>;
         irq-gpios = <&gpio0 2 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
         automouse-layer = <5>;
-        scroll-layers = <6>;
+        scroll-layers = <2>;
 
     };
 };


### PR DESCRIPTION
## Summary
- トラックボールのスクロールモードをレイヤー6からレイヤー2に変更

## Changes
- `config/boards/shields/moNa2/moNa2_R.overlay`のscroll-layersを`<6>`から`<2>`に変更

## Test plan
- [ ] ビルドが成功することを確認
- [ ] レイヤー2でトラックボールがスクロールモードになることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)